### PR TITLE
[chore] change to build apk unsigned if keystore not exists

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,13 +20,13 @@ android {
             val isRunningOnCI = System.getenv("BITRISE") == "true"
             val keystorePropertiesFile = file("../../keystore.properties")
 
-            if (isRunningOnCI || !keystorePropertiesFile.exists()) {
+            if (isRunningOnCI) {
                 println("Signing Config: using environment variables")
                 keyAlias = System.getenv("BITRISEIO_ANDROID_KEYSTORE_ALIAS")
                 keyPassword = System.getenv("BITRISEIO_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD")
                 storeFile = file(System.getenv("KEYSTORE_LOCATION"))
                 storePassword = System.getenv("BITRISEIO_ANDROID_KEYSTORE_PASSWORD")
-            } else {
+            } else if (keystorePropertiesFile.exists()) {
                 println("Signing Config: using keystore properties")
                 val properties = Properties()
                 InputStreamReader(
@@ -40,6 +40,8 @@ android {
                 keyPassword = properties.getProperty("pass")
                 storeFile = file(properties.getProperty("store"))
                 storePassword = properties.getProperty("storePass")
+            } else {
+                println("Signing Config: skipping signing")
             }
         }
     }
@@ -93,7 +95,11 @@ android {
                     "proguard-rules.pro",
                 ),
             )
-            signingConfig = signingConfigs.getByName("release")
+
+            signingConfigs.getByName("release").keyAlias?.let {
+                signingConfig = signingConfigs.getByName("release")
+            }
+
             setOutputFileName()
         }
     }


### PR DESCRIPTION
This is to further split the code signing logic to give up signing if keystore is not specified.