### PR TITLE
CI: provide keystore to dependency submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -20,3 +20,9 @@ jobs:
           java-version: '17'
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v4
+        env:
+          CI: 'true'
+          KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}
+          CI_ANDROID_KEYSTORE_ALIAS: ${{ secrets.CI_ANDROID_KEYSTORE_ALIAS }}
+          CI_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD: ${{ secrets.CI_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD }}
+          CI_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.CI_ANDROID_KEYSTORE_PASSWORD }}


### PR DESCRIPTION
It's just a dummy keystore anyway - we provide it to avoid build errors